### PR TITLE
Less strict matching of YARD tags.

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -69,7 +69,7 @@ syn cluster yardLists contains=yardComma,yardTypeList,yardOrderDependentList
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Yard
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-syn match yardComment "# @!\{,1}\h\+.*" contains=@yardTags,@yardDirectives,yardTypeList
+syn match yardComment "#\s*@!\{,1}\h\+.*" contains=@yardTags,@yardDirectives,yardTypeList
 syn match rubyComment "#.*" contains=rubySharpBang,rubySpaceError,rubyTodo,@Spell,yardComment
 syn region rubyMultilineComment start="\%(\%(^\s*#.*\n\)\@<!\%(^\s*#.*\n\)\)\%(\(^\s*#.*\n\)\{1,}\)\@=" end="\%(^\s*#.*\n\)\@<=\%(^\s*#.*\n\)\%(^\s*#\)\@!" contains=rubyComment transparent fold keepend
 syn cluster rubyNotTop add=@yardTags,@yardDirectives,@yardTypes,@yardLists,@yardHashes


### PR DESCRIPTION
This patch makes it possible for this plugin to match text such as
`#  [multiple spaces here that Github removes because it's a cunt] @return` as YARD tags. Previously it would only match if there was exactly 1 space between the comment character and the @ sign. This would
prevent the plugin from properly highlighting the following code:

```
# @!attribute [r] example
#  @return SomeConstant
```
