### PR TITLE
Use rubyKeyword instead of rubyTodo for keywords

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -79,7 +79,7 @@ syn cluster rubyNotTop add=@yardTags,@yardDirectives,@yardTypes,@yardLists,@yard
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 hi def link yardComment rubyComment
 " Tags
-hi def link yardGenericTag rubyTodo
+hi def link yardGenericTag rubyKeyword
 hi def link yardAbstract yardGenericTag
 hi def link yardApi yardGenericTag
 hi def link yardAttr yardGenericTag
@@ -103,7 +103,7 @@ hi def link yield yardGenericTag
 hi def link yieldparam yardGenericTag
 hi def link yieldreturn yardGenericTag
 " Directives
-hi def link yardGenericDirective rubyTodo
+hi def link yardGenericDirective rubyKeyword
 hi def link yardAttribute yardGenericDirective
 hi def link yardEndGroup yardGenericDirective
 hi def link yardGroup yardGenericDirective


### PR DESCRIPTION
Many themes highlight todo syntax very prominently / ugly. genericTag should not be a todo :)